### PR TITLE
Adds clearer installation instructions, a contents section, and small formatting changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,76 @@ Please note that code will not work in older browsers (Internet Explorer, pre-Ch
 
 If you use [Twee 3 Language Tools](https://github.com/cyrusfirheir/twee3-language-tools) VS Code extension, you might find [`scUtils.twee-config.yaml`](./scUtils.twee-config.yaml) useful, as it contains declarations of all macros in this repo.
 
+---
+
+## Installation
+
+The `*.js` files follow a general pattern of `<macroName>.js` (and possibly `<macroName>.css`) for each macro, and the section explaining each macro links to the corresponding file.
+
+To install:
+- If using the Twine desktop/web app, copy contents of the `*.js` file to `Story JavaScript`, and if relevant, contents of `*.css` file to `Story Stylesheet`.
+- If using a compiler like Tweego, drop the `*.js` — if relevant, `*.css` — files to your source folder.
+
+---
+
+## Contents
+
+### Macros
+
+- [`<<abbr>>` — `<<more>>`](#anchor-more)
+- [`<<dlg>>` — `<<level>>` — `<<line>>`](#anchor-dlg)
+- [`<<gender>>` — `<<genderswitch>>`](#anchor-gender)
+- [`<<hubnav>>`](#anchor-hubnav)
+- [`<<iconcheck>>`](#anchor-iconcheck)
+- [`<<journaladd>>` — `<<journaldisplay>>` — `<<journalreplace>>`](#anchor-journal)
+- [`<<linkif>>`](#anchor-linkif)
+- [`<<linkonce>>`](#anchor-linkonce)
+- [`<<rumble>>`](#anchor-rumble)
+
+### Goodies
+
+- [`Achievements`](#anchor-achievments)
+- [`menuButton.js`](#anchor-menubutton)
+- [`about.js`](#anchor-about)
+- [`daymode.js` — `daymode.css`](#anchor-daymode)
+- [`faint.js`](#anchor-faint)
+- [`fontSize.js`](#anchor-fontsize)
+- [`fullscreen.js`](#anchor-fullscreen)
+- [`LocationFinder.js`](#anchor-locationfinder)
+- [`mute.js`](#anchor-mute)
+- [`pickUnique.js`](#anchor-pickunique)
+- [`plurals-en.js` — `plurals-ru.js`](#anchor-plurals)
+- [`preloadImages.js`](#anchor-preloadimages)
+- [`promiseLock.js`](#anchor-promiselock)
+- [`qbn.js`](#anchor-qbn)
+- [`skipIntro.js`](#anchor-skipintro)
+- [`volumeButtons.js`](#anchor-volumebuttons)
+
+---
 
 ## Macros
 
 Most macros include built-in styles created by JS, so you can copy-paste one file instead of two. Styles are as unobtrusive and neutral as possible.
 
-### `<<abbr "text" "tooltip content">>` and [`<<more "tooltip content">>text<</more>>`](./more.js)
+---
+
+<span id="anchor-more"></span>
+
+### `<<abbr "text" "tooltip content">>` and `<<more "tooltip content">>text<</more>>`
+
+Source: [./more.js](./more.js)
 
 **NB: `<<abbr>>` is deprecated, use `<<more>>`.**
 
 `<<more>>` shows tooltip — on mouse hover on desktop and on tap on touch screen. It tries to contain the tooltip entirely on the screen. `<<more>>` can include SugarCube code inside it, but not in tooltip content.
 
-### [`<<dlg>>`](./dlg.js), `<<level>>` and `<<line>>`.
+---
+
+<span id="anchor-dlg"></span>
+
+### `<<dlg>>`, `<<level>>` and `<<line>>`.
+
+Source: [./dlg.js](./dlg.js)
 
 `<<dlg>>` is split into `<<level>>`s, which, in turn, consist of `<<line>>`s. It will show the player all lines from given level. After player chooses a line, line's content gets appended and next level is displayed.
 
@@ -70,7 +128,13 @@ Setting `prepend` to `true` will make `<<line>>` to prepend this line's visible 
 
 Use variables and `<<if>>`s to create branching.
 
-### [`<<gender>>` and `<<genderswitch>>`](./genderswitch.js)
+---
+
+<span id="anchor-gender"></span>
+
+### `<<gender>>` and `<<genderswitch>>`
+
+Source: [./genderswitch.js](./genderswitch.js)
 
 English grammar is pretty neutral when it comes to gender, but other languages are less forgiving. For instance, in Slavic languages you need to put adjectives and past tense verbs in proper grammatical gender.
 
@@ -81,7 +145,13 @@ English grammar is pretty neutral when it comes to gender, but other languages a
 
 This can also be used to tell a story from perspectives of two persons regardless of grammatical gender.
 
-### [`<<hubnav>>`](./hubnav.js)
+---
+
+<span id="anchor-hubnav"></span>
+
+### `<<hubnav>>`
+
+Source: [./hubnav.js](./hubnav.js)
 
 Easy navigation for set of interconnected locations. Imagine house consisting of bedroom, bathroom, living room, garage and kitchen. Each room has links to other ones but not on itself. Throw in some links that are displayed conditionally and there's whole mess on your hands. `<<hubnav>>` to the rescue!
 ```
@@ -144,7 +214,13 @@ You bought this Vespa trading in retro games.
 Clean, squeky clean, operating room clean.
 ```
 
-### [`<<iconcheck>>`](./iconcheckbox.js)
+---
+
+<span id="anchor-iconcheck"></span>
+
+### `<<iconcheck>>`
+
+Source: [./iconcheckbox.js](./iconcheckbox.js)
 
 Default checkboxes can look ugly and not fit into overall visual style. So `<<iconcheck>>` displays neat switch icon in the same style as built-in SugarCube controls.
 The simplest form is `<<iconcheck $isSomething>>toggle value<</iconcheck>>`, this will display same label no matter what the value is.
@@ -154,7 +230,13 @@ Most flexible form looks like this and allows you to run some callback when valu
 <<iconcheck $isSomething "Turn on" "Turn off" _handler>><</iconcheck>>
 ```
 
-### [`<<journaladd>>`, `<<journaldisplay>>` and `<<journalreplace>>`](./journal.js)
+---
+
+<span id="anchor-journal"></span>
+
+### `<<journaladd>>`, `<<journaldisplay>>` and `<<journalreplace>>`
+
+Source: [./journal.js](./journal.js)
 
 Journals/logs/notes/codexes are found in many games.
 
@@ -185,7 +267,13 @@ Entries content gets rendered when <<journaldisplay>> is used, not when they are
 
 This can also serve as a simple inventory system.
 
-### [``<<linkif [[text|Passage]] `expression`>>``](./linkif.js)
+---
+
+<span id="anchor-linkif"></span>
+
+### ``<<linkif [[text|Passage]] `expression`>>``
+
+Source: [./linkif.js](./linkif.js)
 
 Functionally identical to native [`<<link>>`](http://www.motoslave.net/sugarcube/2/docs/#macros-macro-link), except it's only clickable if second argument is truthy, and just shows plain text otherwise.
 
@@ -201,12 +289,23 @@ There's key here!
 
 Supports any **wiki** form of `[[link|Passage]]`.
 
-### [`<<linkonce [[text|Passage]]>>`](./linkonce.js)
+---
+
+<span id="anchor-linkonce"></span>
+
+### `<<linkonce [[text|Passage]]>>`
+
+Source: [./linkonce.js](./linkonce.js)
 
 Functionally identical to ``<<linkif [[text|Some passage]] `!visited('Some passage')`>>``: shows link if only given passage haven't been visited in current playthrough. Supports any **wiki** form of `[[link|Passage]]`.
 
+---
 
-### [`<<rumble>>`](./rumble.js)
+<span id="anchor-rumble"></span>
+
+### `<<rumble>>`
+
+Source: [./rumble.js](./rumble.js)
 
 Makes your device vibrate, and does nothing if browser/device doesn't [support](https://caniuse.com/#feat=vibration) [Vibration API](https://developer.mozilla.org/docs/Web/API/Navigator/vibrate). Please keep in mind that support is spotty (mostly Android and iOS Chrome and Firefox, no gamepads at all), and long vibrations or sequences can be chopped or dropped entirely, so don't rely on it to convey critical parts of story. Also be polite and provide players with means to turn it off completely.
 
@@ -218,14 +317,22 @@ Makes your device vibrate, and does nothing if browser/device doesn't [support](
 
 Some browsers require user interaction to vibrate, so you'll probably need to wrap this in `<<link>>`.
 
+---
+
 ## Goodies
 
 Most goodies/utils put functions into `window.scUtils` "namespace". Things that create buttons in UIBar rely on `menuButton.js`, so include it in your script before.
 
+---
+
+<span id="anchor-achievments"></span>
+
 ### Achievements
 
+Source: [./achievements](./achievements)
+
 It's not that difficult to create an achievement system, but good achievement system includes many moving parts.
-scUtils' [`achievements`](./achievements) is capable:
+scUtils' `achievements` is capable:
 
 * to provide achievements with title, description, unlock date and flexible checks;
 * to have hidden achievements
@@ -233,36 +340,77 @@ scUtils' [`achievements`](./achievements) is capable:
 * to display achievements as a floating notification in the right bottom corner of player's screen
 * to add a button to the sidebar, which displays a dialog containing list of achievements
 
-Take a look inside the [`achievements/story.twee`](./achievements/story.twee) to learn how to integrate it in your game.
+Take a look inside the [`./achievements/story.twee`](./achievements/story.twee) to learn how to integrate it in your game.
 
+---
 
-### [`menuButton.js`](./menuButton.js)
+<span id="anchor-menubutton"></span>
+
+### `menuButton.js`
+
+Source: [./menuButton.js](./menuButton.js)
 
 Provide `scUtils.createPassageButton(label, iconContent, passageName)` and `scUtils.createHandlerButton(label, iconContent, shortName, handler)` functions. First one creates button which displays dialogue window displaying some passage content.
 
-### [`about.js`](./about.js) (relies on menuButton.js)
+---
+
+<span id="anchor-about"></span>
+
+### `about.js`
+
+Source: [./about.js](./about.js) (relies on menuButton.js)
 
 If story have passage titled `StoryAbout`, adds "About" button which displays dialogue window with this passage rendered inside. Good for providing links to your website/patreon and attributing used assets. To change button label, assign value to correspondent l10n key:`l10nStrings.uiBarAbout = 'Who made this wonderful game?'`
 
-### [`daymode.js`](./daymode.js) and [`daymode.css`](./daymode.css) (relies on menuButton.js)
+---
+
+<span id="anchor-daymode"></span>
+
+### `daymode.js` and `daymode.css`
+
+Source: [./daymode.js](./daymode.js) and [./daymode.css](./daymode.css) (relies on menuButton.js)
 
 Depending on players reading habits, level of fatigue, device, environment and other things author can't predict it can be strainous for eyes to read both white on black or black on white. So let them invert theme when they see fit. Daymode switches your game between default (white on black) theme and (slightly adapted) official but not included bleached.css.
 
-### [`faint.js`](./faint.js)
+---
+
+<span id="anchor-faint"></span>
+
+### `faint.js`
+
+Source: [./faint.js](./faint.js)
 
 Exposes `scUtils.faint(callback, duration, color, blur)` function, which fills screen with solid `color`, `blur`ring content at the same time and calls `callback` after `duration` seconds. Default values are `faint(callback = null, duration = 5, color = 'black', blur = true)`. Keep in mind that not all browsers support this blurring.
 
 Useful for emulating loosing conscience, teleportation, extended periods of time passing, etc.
 
-### [`fontSize.js`](./fontSize.js) (relies on menuButton.js)
+---
+
+<span id="anchor-fontsize"></span>
+
+### `fontSize.js`
+
+Source: [./fontSize.js](./fontSize.js) (relies on menuButton.js)
 
 Exposes `scUtils.createFontSizeBtn` function. When called, this function creates buttons in the sidebar to increase/decrease font size. To change button label, assign value to correspondent l10n key:`l10nStrings.uiFontSize = 'Zoom in/out'` (defaults to 'Font size').
 
-### [`fullscreen.js`](./fullscreen.js) (relies on menuButton.js)
+---
+
+<span id="anchor-fullscreen"></span>
+
+### `fullscreen.js`
+
+Source: [./fullscreen.js](./fullscreen.js) (relies on menuButton.js)
 
 Adds "Full screen" button switch to UIBar (if browser supports this API). Supposedly increases immersion. To change button label, assign value to correspondent l10n key:`l10nStrings.uiFullScreen = 'Immersive mode'`.
 
-### [`LocationFinder.js`](./LocationFinder.js)
+---
+
+<span id="anchor-locationfinder"></span>
+
+### `LocationFinder.js`
+
+Source: [./LocationFinder.js](./LocationFinder.js)
 
 Game can consist of different locations. Suppose you want to change some styles and switch background music depending on whether player is in a dungeon, forest or desert. Using vanilla SugarCube you'll need to assign designated tag to every passage in each location (and 100 passages is not a very big game). Now add music to equation and remember that player can save/load and use checkpoints.
 
@@ -275,13 +423,25 @@ Game can consist of different locations. Suppose you want to change some styles 
 
 **NB: Previously LocationFinder needed `locationOrder-<number>` tags and didn't really support open-world games where player could move freely. Now LocationFinder uses history-based "location" detection, so it's not a problem anymore.**
 
-### [`mute.js`](./mute.js) (relies on menuButton.js)
+---
+
+<span id="anchor-mute"></span>
+
+### `mute.js`
+
+Source: [./mute.js](./mute.js) (relies on menuButton.js)
 
 **NB: Deprecated, use [volumeButtons.js](#volume-buttons)**
 
 Adds "Sound" button switch to UIBar, which mutes/unmutes SugarCube audio engine (note id doesn't stop playback). To change button label, assign value to correspondent l10n key:`l10nStrings.uiBarMute = 'Shut up'`.
 
-### [`pickUnique.js`](pickUnique.js)
+---
+
+<span id="anchor-pickunique"></span>
+
+### `pickUnique.js`
+
+Source: [./pickUnique.js](./pickUnique.js)
 
 [`<Array>.random()`](http://www.motoslave.net/sugarcube/2/docs/#methods-array-prototype-method-random) is a great tool, but sometimes returns same result several times in a row. These helpers solve this problem: each result is guaranteed to be different from previous
 ```js
@@ -306,7 +466,13 @@ Ice cream
 Berries
 ```
 
-### [`plurals-en.js`](./plurals.js) and [`plurals-ru.js`](./plurals-ru.js)
+---
+
+<span id="anchor-plurals"></span>
+
+### `plurals-en.js` and `plurals-ru.js`
+
+Source: [./plurals.js](./plurals.js) and [./plurals-ru.js](./plurals-ru.js)
 
 While English (and most Germanic and Latin languages) only has two plural forms -- singular, and, well, plural, other languages can have more complex rules. For instance, Slavic languages have 3 forms (for 1 item, for 2..5 items, for lots of items, and they start to repeat when you reach 21), and that's not the limit: Arabic has 6 such forms. So to avoid things like "You have 0 message(s)", you need some utility function. `scUtils.pluralize` and `scUtils.pluralizeFmt` provide that.
 
@@ -322,19 +488,36 @@ Both **plurals-en.js** and **plurals-ru.js** expose same two functions, differen
 
 **NB: [`plurals.js`](./plurals.js) contains language independent pluralizer, based on built-in [Intl.PluralRules](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules). Unfortunately, [browser support is still spotty](https://caniuse.com/intl-pluralrules), so it's not really ready for production.**
 
-### [`preloadImages.js`](./preloadImages.js)
+---
+
+<span id="anchor-preloadimages"></span>
+
+### `preloadImages.js`
+
+Source: [./preloadImages.js](./preloadImages.js)
 
 If your logo or background image is heavy, it may take some time to load for a player, resulting in unpleasant effect. You may wish to load images beforehand; `scUtils.preloadImages` shows load screen during this process. It also returns a `Promise` for a finer control on what happens next.
 ```js
 scUtils.preloadImages(['img/heavy-background.jsp', 'img/huge-logo.png']).then(() => console.log('Images loaded!'));
 ```
 
-### [`promiseLock.js`](./promiseLock.js)
+---
+
+<span id="anchor-promiselock"></span>
+
+### `promiseLock.js`
+
+Source: [./promiseLock.js](./promiseLock.js)
 
 If you need to load heave scripts, styles, images or other assets, it may be good idea to show load screen during the process. `window.scUtils.promiseLock` accepts a `Promise` object and shows load screen until the promise resolves successfully.
 
+---
 
-### [`qbn.js`](./qbn.js)
+<span id="anchor-qbn"></span>
+
+### `qbn.js`
+
+Source: [./qbn.js](./qbn.js)
 
 Quest tracker, exposes `window.qbn` and `window.scUtils.qbn` objects.
 
@@ -351,7 +534,13 @@ qbn.inc('madness', 12); // time to eat your crew yet?
 qbn.dec('madness', 5); // qbn.length('madness') === 7
 ```
 
-### [`skipIntro.js`](./skipIntro.js)
+---
+
+<span id="anchor-skipintro"></span>
+
+### `skipIntro.js`
+
+Source: [./skipIntro.js](./skipIntro.js)
 
 Simple utility that inserts "Skip intro" link into certain passages starting from 2nd playthrough.
 ```js
@@ -370,7 +559,13 @@ p.skipIntro {
 }
 ```
 
-### [`volumeButtons.js`](./volumeButtons.js) (relies on menuButton.js) {#volume-buttons}
+---
+
+<span id="anchor-volumebuttons"></span>
+
+### `volumeButtons.js`
+
+Source: [./volumeButtons.js](./volumeButtons.js) (relies on menuButton.js)
 
 Exposes `scUtils.createVolumeButtons` function, which adds volume control buttons to the UI bar. To change button label, assign value to correspondent l10n key:`l10nStrings.uiVolumeControl = 'Level of AWESOME'`.
 
@@ -380,7 +575,9 @@ const labels = ['🔈', '🔇', '🔊'];
 scUtils.createVolumeButtons(step, volume);
 ```
 
-## Using the code {#using-the-code}
+---
+
+## Using the code
 
 Code in the repo uses pretty new JS language features and as-is will work only in fresh Chrome and FF and latest Safari (last 2-3 years). This is fine if you're wrapping your game in NW.js or Electron or during debug stages, but may be unacceptable for web distribution. To remedy that, use `bin/build.js` script like so:
 ```sh
@@ -393,6 +590,8 @@ node bin/build.js --es6 --compress abbr about faint genderswitch
 ```
 
 By default, code will be transpiled to support same browsers as SugarCube. If you don't have node.js installed, you can transpile code [online](http://babeljs.io/repl/).
+
+---
 
 ## MIT License
 Copyright 2017-2020 Konstantin Kitmanov.


### PR DESCRIPTION
Recently, someone was having trouble understanding the README, specifically how to install, what files to copy, etc. Looking over it, I could see how it could get confusing, so I made some edits. And a couple broken links in the process. I have tested all the links, but might have missed a few, so would be nice if you could check them yourself too.